### PR TITLE
 Add history as top-level dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby-starter-blog#readme",
   "dependencies": {
+    "history": "^2.0.0",
     "lodash": "^4.5.0",
     "moment": "^2.11.2",
     "react": "^0.14.7",


### PR DESCRIPTION
was causing the webpack build to fail (cf similar problem fixed in gatsbyjs/gatsby/pull/174)