### PR TITLE
Fix double-prefixing of profile picture.

### DIFF
--- a/components/Bio.js
+++ b/components/Bio.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { config } from 'config'
 import { rhythm } from 'utils/typography'
-import { prefixLink } from 'gatsby-helpers'
 import profilePic from './profile-pic.jpg'
 
 class Bio extends React.Component {
@@ -13,7 +12,7 @@ class Bio extends React.Component {
         }}
       >
         <img
-          src={prefixLink(profilePic)}
+          src={profilePic}
           alt={`author ${config.authorName}`}
           style={{
             float: 'left',


### PR DESCRIPTION
I don't know if this was happening to other people, but for me the profile picture was getting sourced as `/prefix/prefix/profile-pic.jpg`, which led to a broken image in production (worked fine in development). This fixed it for me.