### PR TITLE
delete config.toml cause seems unused

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,0 @@
-blogTitle = "My Awesome Blog"
-authorName = "Kyle Mathews"
-linkPrefix = "/gatsby-starter-blog"


### PR DESCRIPTION
With gatsbyjs/gatsby@66f90132b4a73a9d880587efa96f8cb2dc9c7cf0 the code loading this config has been removed. So the config seems obsolete.