### PR TITLE
React.PropTypes.function should be React.PropTypes.func

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -66,7 +66,7 @@ class Template extends React.Component {
 }
 
 Template.propTypes = {
-  children: React.PropTypes.function,
+  children: React.PropTypes.func,
   location: React.PropTypes.object,
   route: React.PropTypes.object,
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -18,7 +18,7 @@ class BlogIndex extends React.Component {
         const title = get(post, "node.frontmatter.title") || post.node.path
         pageLinks.push(
           <li
-            key={post.node.path}
+            key={post.node.fields.slug}
             style={{
               marginBottom: rhythm(1 / 4),
             }}


### PR DESCRIPTION
This is warning on console about the error:
```
warning.js:36 Warning: Failed prop type: Template: prop type `children` is invalid; it must be a function, usually from React.PropTypes.
    in Template (created by Route)
    in Route (created by withRouter(Template))
    in withRouter(Template) (created by Root)
    in ScrollContext (created by Route)
    in Route (created by withRouter(ScrollContext))
    in withRouter(ScrollContext) (created by Root)
    in Router (created by BrowserRouter)
    in BrowserRouter (created by DefaultRouter)
    in DefaultRouter (created by Root)
    in Root
    in AppContainer
```
I think this may be a typo mistake, and React.PropTypes.function should be React.PropTypes.func.
Refer to https://facebook.github.io/react/docs/typechecking-with-proptypes.html