### PR TITLE
Fixed an issue that caused following bug

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,7 +17,7 @@ class BlogIndex extends React.Component {
         const title = get(post, "node.frontmatter.title") || post.node.path
         pageLinks.push(
           <li
-            key={post.node.path}
+            key={post.node.frontmatter.path}
             style={{
               marginBottom: rhythm(1 / 4),
             }}


### PR DESCRIPTION
Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `BlogIndex`. See https://fb.me/react-warning-keys for more information.