### PR TITLE
Corrected options for gatsby-plugin-typography.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -45,7 +45,9 @@ module.exports = {
     `gatsby-plugin-react-helmet`,
     {
       resolve: "gatsby-plugin-typography",
-      pathToConfigModule: "src/utils/typography",
+      options: {
+        pathToConfigModule: "src/utils/typography",
+      },
     },
   ],
 }


### PR DESCRIPTION
Moved pathToConfigModule to options object. Otherwise it was not using the custom defined typography during build.