### PR TITLE
Warning fixes

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -66,7 +66,7 @@ class Template extends React.Component {
 }
 
 Template.propTypes = {
-  children: React.PropTypes.function,
+  children: React.PropTypes.func,
   location: React.PropTypes.object,
   route: React.PropTypes.object,
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -19,9 +19,10 @@ class BlogIndex extends React.Component {
           if (post.node.path !== "/404/") {
             const title = get(post, "node.frontmatter.title") || post.node.path
             return (
-              <div>
+              <div
+                key={post.node.frontmatter.path}
+              >
                 <h3
-                  key={post.node.frontmatter.path}
                   style={{
                     marginBottom: rhythm(1 / 4),
                   }}


### PR DESCRIPTION
At `layouts/index.js`, `PropTypes.function` should be `PropTypes.func`. And at `pages/index.js`, `key` is in the wrong tag (should be`div` instead of `h3`).

That fix two red warnings:
- Warning: Failed prop type: Template: prop type `children` is invalid; it must be a function, usually from React.PropTypes.
- Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `BlogIndex`. See https://fb.me/react-warning-keys for more information.