### PR TITLE
Remove underline for hyperlinked images

### DIFF
--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -1,6 +1,12 @@
 import Typography from 'typography'
 import Wordpress2016 from 'typography-theme-wordpress-2016'
 
+Wordpress2016.overrideThemeStyles = () => ({
+  'a.gatsby-resp-image-link': {
+    boxShadow: 'none',
+  }
+})
+
 const typography = new Typography(Wordpress2016)
 
 // Hot reload typography in development.


### PR DESCRIPTION
Hyperlinked images shouldn't be underlined.

![giphy](https://user-images.githubusercontent.com/6865958/31855809-0c6f8fc4-b6b3-11e7-941d-ed2006481889.gif)
