### PR TITLE
remove react-responsive-grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3986,11 +3986,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
       "integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk="
     },
-    "element-resize-event": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/element-resize-event/-/element-resize-event-2.0.9.tgz",
-      "integrity": "sha1-L14VgaKW61J1IQwUG8VjQuIY+HY="
-    },
     "elliptic": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
@@ -12456,21 +12451,6 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
       "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
     },
-    "raf": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-2.0.4.tgz",
-      "integrity": "sha1-SZPkU+pSdb9u8HoWO9/pojIztiM=",
-      "requires": {
-        "performance-now": "0.1.4"
-      },
-      "dependencies": {
-        "performance-now": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.1.4.tgz",
-          "integrity": "sha1-NgtkLwc/+MKmk7PDjXzLwXtTGDs="
-        }
-      }
-    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -12599,14 +12579,6 @@
         "prop-types": "15.5.10"
       }
     },
-    "react-component-width-mixin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-component-width-mixin/-/react-component-width-mixin-2.0.0.tgz",
-      "integrity": "sha1-lhKAYpnM894jBPjUD7AufBTSoTE=",
-      "requires": {
-        "element-resize-event": "2.0.9"
-      }
-    },
     "react-deep-force-update": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz",
@@ -12730,30 +12702,12 @@
         }
       }
     },
-    "react-page-width": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-page-width/-/react-page-width-1.0.1.tgz",
-      "integrity": "sha1-Jk5b/+PNKn16num7gA32MzqqyZA=",
-      "requires": {
-        "raf": "2.0.4"
-      }
-    },
     "react-proxy": {
       "version": "3.0.0-alpha.1",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
       "integrity": "sha1-RABCa8+oDKpnJMd1VpUxUgn6Swc=",
       "requires": {
         "lodash": "4.17.5"
-      }
-    },
-    "react-responsive-grid": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/react-responsive-grid/-/react-responsive-grid-0.3.4.tgz",
-      "integrity": "sha1-yU/aFGnzakHj/CP2O7blD16GZSM=",
-      "requires": {
-        "object-assign": "4.1.1",
-        "react-component-width-mixin": "2.0.0",
-        "react-page-width": "1.0.1"
       }
     },
     "react-router": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "gatsby-transformer-remark": "^1.7.40",
     "gatsby-transformer-sharp": "^1.6.22",
     "lodash": "^4.17.5",
-    "react-responsive-grid": "^0.3.4",
     "typeface-merriweather": "0.0.43",
     "typeface-montserrat": "0.0.43",
     "typography-theme-wordpress-2016": "^0.15.10"

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import Link from 'gatsby-link'
-import { Container } from 'react-responsive-grid'
 
 import { rhythm, scale } from '../utils/typography'
 
@@ -58,15 +57,17 @@ class Template extends React.Component {
       )
     }
     return (
-      <Container
+      <div
         style={{
+          marginLeft: 'auto',
+          marginRight: 'auto',
           maxWidth: rhythm(24),
           padding: `${rhythm(1.5)} ${rhythm(3 / 4)}`,
         }}
       >
         {header}
         {children()}
-      </Container>
+      </div>
     )
   }
 }


### PR DESCRIPTION
The package, which is used only once, is causing a createClass deprecation warning. I've replaced the Container component, taking a cue from the [react-responsive-grid repo](https://github.com/KyleAMathews/react-responsive-grid/blob/master/src/components/Container.cjsx).