### PR TITLE
Use site metadata as title

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -6,6 +6,7 @@ import { rhythm, scale } from '../utils/typography'
 class Template extends React.Component {
   render() {
     const { location, children } = this.props
+    const { title } = this.props.data.site.siteMetadata
     let header
 
     let rootPath = `/`
@@ -30,7 +31,7 @@ class Template extends React.Component {
             }}
             to={'/'}
           >
-            Gatsby Starter Blog
+            {title}
           </Link>
         </h1>
       )
@@ -51,7 +52,7 @@ class Template extends React.Component {
             }}
             to={'/'}
           >
-            Gatsby Starter Blog
+            {title}
           </Link>
         </h3>
       )
@@ -73,3 +74,13 @@ class Template extends React.Component {
 }
 
 export default Template
+
+export const query = graphql`
+  query LayoutIndexQuery {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }
+`


### PR DESCRIPTION
I noticed that the title of the blog was duplicated in the layout.

Was using this template and wanted to be able to change the title without changing the JavaScript.