### PR TITLE
Hide Draft Posts

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,7 +12,8 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
       graphql(
         `
           {
-            allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }, limit: 1000) {
+            allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }, limit: 1000,
+            filter: {frontmatter: {draft: {ne : true } } }) {
               edges {
                 node {
                   fields {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -47,7 +47,8 @@ export const pageQuery = graphql`
         title
       }
     }
-    allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
+    allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }
+    filter: {frontmatter: {draft: {ne: true } } }) {
       edges {
         node {
           excerpt
@@ -55,7 +56,7 @@ export const pageQuery = graphql`
             slug
           }
           frontmatter {
-            date(formatString: "DD MMMM, YYYY")
+            date(formatString: "MMMM DD, YYYY")
             title
           }
         }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -56,7 +56,7 @@ export const pageQuery = graphql`
             slug
           }
           frontmatter {
-            date(formatString: "MMMM DD, YYYY")
+            date(formatString: "DD MMMM, YYYY")
             title
           }
         }


### PR DESCRIPTION
Attempted to address  [https://github.com/gatsbyjs/gatsby-starter-blog/issues/103](https://github.com/gatsbyjs/gatsby-starter-blog/issues/103) by filtering graphql post queries to hide posts that are marked as draft in the front matter `draft: true`. 


