### PR TITLE
Fix `window is not defined` error during build

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -6,15 +6,8 @@ import { rhythm, scale } from '../utils/typography'
 class Template extends React.Component {
   render() {
     const { location, children } = this.props
+    const rootPath = `${__PATH_PREFIX__}/`
     let header
-
-    let rootPath = `/`
-    if (
-      typeof window.__PREFIX_PATHS__ !== `undefined` &&
-      window.__PREFIX_PATHS__
-    ) {
-      rootPath = window.__PATH_PREFIX__ + `/`
-    }
 
     if (location.pathname === rootPath) {
       header = (


### PR DESCRIPTION
__PATH_PREFIX__ is always defined now (it defaults to an empty string ), so checking for __PREFIX_PATHS__ isn't necessary any more. This fixes `gatsby build` for this branch.