### PR TITLE
Corrected formatting of next and previous links in blog post template

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -43,21 +43,22 @@ class BlogPostTemplate extends React.Component {
             padding: 0,
           }}
         >
-          {previous && (
-            <li>
+          <li>
+            {
+              previous &&
               <Link to={previous.fields.slug} rel="prev">
                 ← {previous.frontmatter.title}
               </Link>
-            </li>
-          )}
-
-          {next && (
-            <li>
+            }
+          </li>
+          <li>
+            {
+              next &&
               <Link to={next.fields.slug} rel="next">
                 {next.frontmatter.title} →
               </Link>
-            </li>
-          )}
+            }
+          </li>
         </ul>
       </div>
     )


### PR DESCRIPTION
This change corrects the formatting of the `previous` and `next` links on the blog post template in the case that either `previous` or `next` don't exist. Rendering an empty `<li>` in this case, rather than rendering nothing at all, allows the parent `<ul>` flexbox to display the links correctly. 

To see the difference, open the first and last blog posts and check the position of the `next` and `previous` links. 