### PR TITLE
[v2] import graphql from gatsby

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Helmet from 'react-helmet'
-import { Link } from 'gatsby'
+import { Link, graphql } from 'gatsby'
 import get from 'lodash/get'
 
 import Bio from '../components/Bio'


### PR DESCRIPTION
This imports graphql from gatsby for the blog-post template. This follows the [upgrading docs](https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#import-graphql-from-gatsby).