### PR TITLE
make date format consistent with blog post template

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -65,7 +65,7 @@ export const pageQuery = graphql`
             slug
           }
           frontmatter {
-            date(formatString: "DD MMMM, YYYY")
+            date(formatString: "MMMM DD, YYYY")
             title
           }
         }


### PR DESCRIPTION
The queries in `index.js` and `blog-post.js` have different date formats. Since many users may never change these formats, better to be consistent by default.