### PR TITLE
Fix capitalization for component imports

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import Layout from '../components/layout'
+import Layout from '../components/Layout'
 import SEO from '../components/seo'
 
 class NotFoundPage extends React.Component {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Link, graphql } from 'gatsby'
 
-import Bio from '../components/bio'
-import Layout from '../components/layout'
+import Bio from '../components/Bio'
+import Layout from '../components/Layout'
 import SEO from '../components/seo'
 import { rhythm } from '../utils/typography'
 

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Link, graphql } from 'gatsby'
 
-import Bio from '../components/bio'
-import Layout from '../components/layout'
+import Bio from '../components/Bio'
+import Layout from '../components/Layout'
 import SEO from '../components/seo'
 import { rhythm, scale } from '../utils/typography'
 


### PR DESCRIPTION
A previous change introduced lower case filenames for the import path, causing the build to fail on case sensitive file systems.