### PR TITLE
Remove negative index on site title for non index pages

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -36,7 +36,6 @@ class Layout extends React.Component {
           style={{
             fontFamily: `Montserrat, sans-serif`,
             marginTop: 0,
-            marginBottom: rhythm(-1),
           }}
         >
           <Link


### PR DESCRIPTION
I copied the index page to `pages/blog.js` file and opened the page to see this:

<img width="604" alt="capture d ecran 2019-01-01 a 14 40 14" src="https://user-images.githubusercontent.com/5597274/50576244-3467f700-0dd3-11e9-929f-0304c4b95bc0.png">

I tracked it down to the negative margin added by `Layout.js` for non-index files. Removing the `marginBottom` (thereby using the default value) resulted in:

<img width="629" alt="capture d ecran 2019-01-01 a 14 40 27" src="https://user-images.githubusercontent.com/5597274/50576248-55c8e300-0dd3-11e9-9882-16cb57d0b403.png">
