### PR TITLE
feat: show header on 404 pages to easily navigate back to homepage

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -5,8 +5,11 @@ import SEO from '../components/seo'
 
 class NotFoundPage extends React.Component {
   render() {
+    const { data } = this.props
+    const siteTitle = data.site.siteMetadata.title
+
     return (
-      <Layout location={this.props.location}>
+      <Layout location={this.props.location} title={siteTitle}>
         <SEO title="404: Not Found" />
         <h1>Not Found</h1>
         <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
@@ -16,3 +19,13 @@ class NotFoundPage extends React.Component {
 }
 
 export default NotFoundPage
+
+export const pageQuery = graphql`
+  query {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }
+`


### PR DESCRIPTION
By adding the `title` to the `Layout` components, we allow for easy navigation back to the homepage.

Before:
![screen shot 2019-01-06 at 6 47 41 am](https://user-images.githubusercontent.com/127199/50737528-405f0a80-117f-11e9-9d8b-86e3bb3b58c4.png)
After:
![screen shot 2019-01-06 at 6 47 25 am](https://user-images.githubusercontent.com/127199/50737529-4228ce00-117f-11e9-9ede-d253a0439cab.png)
