### PR TITLE
fix readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ _Have another more specific idea? You may want to check out our vibrant collecti
 
     ```sh
     cd my-blog-starter/
-    gatsby develop
+    npx gatsby develop
     ```
 
 1.  **Open the source code and start editing!**


### PR DESCRIPTION
I think people that do not install `gatsby-cli` can't use `gatsby` command in terminal.

So, I added `npx` in front of `gatsby` like above.

thanks.