### PR TITLE
Provide fallback content when JavaScript is disabled and reach PWA score of 100 in Lighthouse

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,39 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+export default class HTML extends React.Component {
+  render() {
+    return (
+      <html {...this.props.htmlAttributes}>
+        <head>
+          <meta charSet="utf-8" />
+          <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+          <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, shrink-to-fit=no"
+          />
+          {this.props.headComponents}
+        </head>
+        <body {...this.props.bodyAttributes}>
+          {this.props.preBodyComponents}
+          <noscript>You need to enable JavaScript to run this app.</noscript>
+          <div
+            key={`body`}
+            id="___gatsby"
+            dangerouslySetInnerHTML={{ __html: this.props.body }}
+          />
+          {this.props.postBodyComponents}
+        </body>
+      </html>
+    )
+  }
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+}


### PR DESCRIPTION
As reported  here: https://github.com/gatsbyjs/gatsby/issues/6559#issuecomment-453818178

This PR provides feedback to the user when JavaScript is disabled and also improves the PWA lighthouse score from `96` to `100`.

![image](https://user-images.githubusercontent.com/4155121/51084760-e7bbde80-1737-11e9-9816-b3305eb6be9a.png)

![image](https://user-images.githubusercontent.com/4155121/51084765-03bf8000-1738-11e9-8cfa-4545dbdb0f7a.png)

The downside maybe is that `html.js` is exposed by default, as I wasn't able to come up with a better where to include the `noscript` tag. Not sure if that's a deal breaker? Looks ok to me, but I'm not sure if you want to keep `html.js` abstracted away from the user by default. Let me know what you think.

