### PR TITLE
Fix: ESLint 'ecmaVersion' in 'parserOptions'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,8 +11,8 @@ module.exports = {
   },
   "parserOptions": {
     "sourceType": "module",
+    "ecmaVersion": 2018,
     "ecmaFeatures": {
-      "ecmaVersion": 2018,
       "jsx": true,
     },
   }


### PR DESCRIPTION
Summary: This was causing the linting tests to fail as the option was not taken into account, being under `parserOptions.ecmaFeatures` instead of `parserOptions`.

### Before

```
~/P/gatsby-starter-blog (master|✔) $ yarn lint
yarn run v1.13.0
$ eslint --ext .js,.jsx --ignore-pattern public .

/Users/robin/Perso/gatsby-starter-blog/src/components/Layout.js
  16:13  error  Parsing error: Unexpected token ..

/Users/robin/Perso/gatsby-starter-blog/src/templates/blog-post.js
  21:13  error  Parsing error: Unexpected token ..

✖ 2 problems (2 errors, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### After

```
~/P/gatsby-starter-blog (master|✚1) $ yarn lint
yarn run v1.13.0
$ eslint --ext .js,.jsx --ignore-pattern public .
✨  Done in 0.96s.
```
