### PR TITLE
Changing the navigation from a post because of the posts order

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -34,8 +34,8 @@ exports.createPages = ({ graphql, actions }) => {
     const posts = result.data.allMarkdownRemark.edges
 
     posts.forEach((post, index) => {
-      const previous = index === posts.length - 1 ? null : posts[index + 1].node
-      const next = index === 0 ? null : posts[index - 1].node
+      const next = index === posts.length - 1 ? null : posts[index + 1].node
+      const previous = index === 0 ? null : posts[index - 1].node
 
       createPage({
         path: post.node.fields.slug,


### PR DESCRIPTION
Hi,

This is a proposal, because I think it's a little confusing. I'm not the only one who experimented the same thing: the list of posts is in reverse order of date; however, the previous and next navigation from a post follows the order of date (not reverse).

This small change keeps the same order both the main list and a single post.

Best regards!