### PR TITLE
set a description field on first blog

### DIFF
--- a/content/blog/hello-world/index.md
+++ b/content/blog/hello-world/index.md
@@ -1,6 +1,7 @@
 ---
 title: Hello World
 date: "2015-05-01T22:12:03.284Z"
+description: "Hello World"
 ---
 
 This is my first post on my new fake blog! How exciting!


### PR DESCRIPTION
I discovered Gatsby a couple weeks ago.  Great framework!  I am pivoting my career to Web and Mobile (from embedded firmware) so I only have a limited amount of experience with React and Gatsby.  This PR is an idea to help the next person who uses this starter.

I think a common use of starter is to clone it and remove all but first blog entry.  Unfortunately this will cause error with graphql query since there are no description fields in any blog posts.  I saw a proposal to add default setting for frontmatter/gatsby-transformer-remark but I thing that feature may have been dropped.