### PR TITLE
Add Fathom Analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -53,6 +53,15 @@ module.exports = {
         //trackingId: `ADD YOUR TRACKING ID HERE`,
       },
     },
+    {
+      resolve: 'gatsby-plugin-fathom',
+      options: {
+        // Fathom server URL. Defaults to `cdn.usefathom.com`
+        // trackingUrl: 'your-fathom-instance.com',
+        
+        // siteId: 'ADD YOUR SITE ID HERE'
+      }
+    },
     `gatsby-plugin-feed`,
     {
       resolve: `gatsby-plugin-manifest`,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby-image": "^2.2.17",
     "gatsby-plugin-feed": "^2.3.11",
     "gatsby-plugin-google-analytics": "^2.1.14",
+    "gatsby-plugin-fathom": "^1.1.0",
     "gatsby-plugin-manifest": "^2.2.14",
     "gatsby-plugin-offline": "^2.2.10",
     "gatsby-plugin-react-helmet": "^3.1.6",


### PR DESCRIPTION
[Fathom Analytics](https://usefathom.com) is a great privacy first alternative to Google Analytics.

Adding it to this project would allow easier setup and configuration, as well as encourage to use a privacy-first analytics platform.