### PR TITLE
update siteUrl to resolve CORS issues

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,7 @@ module.exports = {
       summary: `who lives and works in San Francisco building useful things.`,
     },
     description: `A starter blog demonstrating what Gatsby can do.`,
-    siteUrl: `https://gatsby-starter-blog-demo.netlify.com/`,
+    siteUrl: `https://gatsby-starter-blog-demo.netlify.app/`,
     social: {
       twitter: `kylemathews`,
     },


### PR DESCRIPTION
Netlify recently changed their static site links from .com to .app. While this link about the URL changes (https://community.netlify.com/t/changes-coming-to-netlify-site-urls/8918) says that the old .com links will redirect to .app it seems to be causing CORS issues in the demo app 
<img width="1440" alt="Screen Shot 2020-05-05 at 4 19 36 PM" src="https://user-images.githubusercontent.com/6998954/81112294-6835be00-8eec-11ea-861b-29fb043b1f33.png">
<img width="1440" alt="Screen Shot 2020-05-05 at 4 19 46 PM" src="https://user-images.githubusercontent.com/6998954/81112295-68ce5480-8eec-11ea-86fa-59e506a42e69.png">

The demo app seems to work as expected at: https://gatsby-starter-blog-demo.netlify.app/new-beginnings/ 

The demo link on GithHub in this template's description should also be updated to point to .app instead of .com by whoever has edit access to this repo's URL box