### PR TITLE
fix: 🐛 add typescript formatting to prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",


### PR DESCRIPTION
This an derived starter templates have `.ts` or `.tsx` files that are not being processed by Prettier when running.

This PR addresses that.

I would ask if we need to fix this in other repos but I looked at the main one and they do it differently there... maybe we should also not filter by file type?