### PR TITLE
Add Deploy on Platform.sh option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,10 @@ Looking for more guidance? Full documentation for Gatsby lives [on the website](
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/gatsbyjs/gatsby-starter-blog)
 
+<p align="center">
+<a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/gatsby/.platform.template.yaml&utm_content=gatsby&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
+    <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
+</a>
+</p>
+
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/README.md
+++ b/README.md
@@ -96,10 +96,8 @@ Looking for more guidance? Full documentation for Gatsby lives [on the website](
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/gatsbyjs/gatsby-starter-blog)
 
-<p align="center">
 <a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/gatsby/.platform.template.yaml&utm_content=gatsby&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
     <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
 </a>
-</p>
 
 <!-- AUTO-GENERATED-CONTENT:END -->


### PR DESCRIPTION
We pull `gatsby-starter-blog` regularly to seed our template (https://github.com/platformsh-templates/gatsby), only including our configuration files to deploy on Platform.sh. 