### PR TITLE
Change react-helmet to react-helmet-async

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -69,7 +69,7 @@ module.exports = {
         icon: `content/assets/gatsby-icon.png`,
       },
     },
-    `gatsby-plugin-react-helmet`,
+    `gatsby-plugin-react-helmet-async`,
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gatsby-plugin-google-analytics": "^2.5.0",
     "gatsby-plugin-manifest": "^2.6.1",
     "gatsby-plugin-offline": "^3.4.0",
-    "gatsby-plugin-react-helmet": "^3.4.0",
+    "gatsby-plugin-react-helmet-async": "^1.1.0",
     "gatsby-plugin-sharp": "^2.8.0",
     "gatsby-remark-copy-linked-files": "^2.4.0",
     "gatsby-remark-images": "^3.5.1",
@@ -27,7 +27,7 @@
     "prismjs": "^1.22.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "react-helmet": "^5.2.1",
+    "react-helmet-async": "^1.0.7",
     "typeface-merriweather": "0.0.72",
     "typeface-montserrat": "0.0.75"
   },

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -7,7 +7,7 @@
 
 import React from "react"
 import PropTypes from "prop-types"
-import { Helmet } from "react-helmet"
+import { Helmet } from "react-helmet-async"
 import { useStaticQuery, graphql } from "gatsby"
 
 const SEO = ({ description, lang, meta, title }) => {


### PR DESCRIPTION
react-helmet has causing below console error:
```
Warning: Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.

Please update the following components: SideEffect(NullComponent)
```
Please check this issue https://github.com/nfl/react-helmet/issues/548.
And react-helmet has async issue too. of course gatsby is not SSR framework but has problem potential.
react-helmet-async is solved this problem and gatsby has gatsby-plugin-react-helmet-asnyc.

what about change react-helmet to react-helmet-async?