### PR TITLE
Fix broken placehold.it links in example post

### DIFF
--- a/content/blog/hello-world/index.md
+++ b/content/blog/hello-world/index.md
@@ -226,6 +226,6 @@ This paragraph has some `code` in it.
 
     This paragraph has some `code` in it.
 
-![Alt Text](https://placehold.it/200x50 "Image Title")
+![Alt Text](https://via.placeholder.com/200x50 "Image Title")
 
-    ![Alt Text](https://placehold.it/200x50 "Image Title")
+    ![Alt Text](https://via.placeholder.com/200x50 "Image Title")


### PR DESCRIPTION
It appears that placehold.it is no longer a valid API, the new one is: `https://via.placeholder.com/zxy`

Documentation found here: https://placeholder.com/#How_To_Use_Our_Placeholders