### PR TITLE
Add Gitlab CI configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,12 @@
+pages:
+  stage: test
+  image: node:latest
+  cache:
+    paths: ["node_modules"]
+  script: 
+    - npm install
+    - npm run build
+  artifacts:
+    expire_in: 1 days
+    paths:
+      - public


### PR DESCRIPTION
Adds a basic gitlab configuration which deploys the page on gitlab pages.

This is ideal for testing purposes and for users who do not know how to setup a gitlab pipeline.